### PR TITLE
Fix "no overall checkmk notifications anymore" if curl timeout happens

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Edit your user and enter your Group/Chat-ID
 
 ## TROUBLESHOOTING
 For more details and troubleshooting with parameters please check:
-* Check_MK notification logfile: /omd/sites/{sitename}/var/log/notify.log
+* Check_MK notification logfile: ```tail -f /omd/sites/{sitename}/var/log/notify.log```
 * [Check_MK  Manual > Notifications > Chapter: 11.3. A simple example](https://docs.checkmk.com/latest/en/notifications.html#H1:Real)
 * [[Feature-Request] Multiple Alert Profiles](https://github.com/filipnet/checkmk-telegram-notify/issues/3)
 

--- a/check_mk_telegram-notify.sh
+++ b/check_mk_telegram-notify.sh
@@ -102,11 +102,12 @@ MESSAGE+="%0AIPv4: ${NOTIFY_HOST_ADDRESS_4} %0AIPv6: ${NOTIFY_HOST_ADDRESS_6}%0A
 MESSAGE+="${NOTIFY_SHORTDATETIME} | ${OMD_SITE}"
 
 # Send message to Telegram bot
-response=$(curl -S -s -q -X POST "https://api.telegram.org/bot${TOKEN}/sendMessage" -d chat_id="${CHAT_ID}" -d text="${MESSAGE}")
+response=$(curl -S -s -q --connect-timeout 5 -X POST "https://api.telegram.org/bot${TOKEN}/sendMessage" -d chat_id="${CHAT_ID}" -d text="${MESSAGE}")
 if [ $? -ne 0 ]; then
         echo "Not able to send Telegram message" >&2
         echo $response >&2
         exit 2
 else
+        echo "Telegramm message send sucessfull" >&2
         exit 0
 fi


### PR DESCRIPTION
Curl timeouts (eg. IPv6 Network with non working PMTUD) have the effect for CheckMK that the whole notify process will aborted and not only this single plugin.

Added a timeout to the curl request (if you get no connect in 5 sec. forgot it ;)). With this the other notifications plugins are executed as expected from the CheckMK executor

Sample log output:

2024-07-27 21:05:16,787 [20] [cmk.base.notify]      Output: curl: (28) Operation timed out after 5001 milliseconds with 0 out of 0 bytes received
2024-07-27 21:05:16,788 [20] [cmk.base.notify]      Output: Not able to send Telegram message
2024-07-27 21:05:16,789 [20] [cmk.base.notify]      Output:
2024-07-27 21:05:16,789 [20] [cmk.base.notify]      Plugin exited with code 2
.. other notification plugins following and working